### PR TITLE
Fix intermittent test failure

### DIFF
--- a/src/test/kotlin/no/nav/helse/SpadeComponentTest.kt
+++ b/src/test/kotlin/no/nav/helse/SpadeComponentTest.kt
@@ -203,7 +203,7 @@ class SpadeComponentTest {
                addHeader(HttpHeaders.Authorization, "Bearer $token")
                addHeader(HttpHeaders.Origin, "http://localhost")
             }.apply {
-               if (response.status() == HttpStatusCode.ServiceUnavailable) {
+               if (response.status() == HttpStatusCode.ServiceUnavailable || response.status() == HttpStatusCode.NotFound) {
                   Thread.sleep(1000)
                   makeRequest(søknadId, maxRetryCount, retryCount + 1)
                } else {


### PR DESCRIPTION
Seems that Kafka was rebalancing due to client connect, and bad timing could result
in 404 being returned temporarily.